### PR TITLE
Use individual intermediate files

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -32,3 +32,4 @@ executables:
      - RenderDocument
      - LatexPreamble
      - OutputParser
+     - Utilities

--- a/src/OutputParser.hs
+++ b/src/OutputParser.hs
@@ -8,14 +8,15 @@ where
 import Core.Text
 import qualified Data.ByteString.Lazy.Char8 as L
 
---
--- The build command returned a non-zero exit code, so there is a
--- reasonable assumption that there is indeed an error to be extracted.
---
-parseOutputForError :: FilePath -> L.ByteString -> Rope
-parseOutputForError file =
+{-
+The build command returned a non-zero exit code, so there is a
+reasonable assumption that there is indeed an error to be extracted.
+-}
+-- Originally written in lazy ByteString as that is output from readProcess
+parseOutputForError :: FilePath -> Rope -> Rope
+parseOutputForError tmpdir =
   let
-    needle = L.snoc (L.pack file)  ':'
+    needle = L.pack tmpdir
 
     stripBeginning [] = []
     stripBeginning (b:bs) = if L.isPrefixOf needle b
@@ -27,7 +28,7 @@ parseOutputForError file =
         then []
         else b : dropEnding bs
   in
-    intoRope . L.intercalate "\n" . dropEnding . stripBeginning . L.lines
+    intoRope . L.intercalate "\n" . dropEnding . stripBeginning . L.lines . fromRope
 
 
 -- Error stream from xelatex looks like this:

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Utilities
+    ( ensureDirectory
+    , execProcess
+    )
+where
+
+import Control.Monad (when)
+import Core.Program
+import Core.System
+import Core.Text
+import qualified Data.List as List (intercalate)
+import System.Directory (doesDirectoryExist, createDirectory)
+import System.Exit (ExitCode(..))
+import System.FilePath.Posix (takeDirectory)
+import System.Process.Typed (proc, readProcess, setStdin, closed)
+
+{-
+Some source files live in subdirectories. Replicate that directory
+structure in the temporary build space
+-}
+ensureDirectory :: FilePath -> Program a ()
+ensureDirectory target =
+  let
+     subdir = takeDirectory target
+  in liftIO $ do
+    probe <- doesDirectoryExist subdir
+    when (not probe) $ do
+        createDirectory subdir
+
+{-
+Thin wrapper around **typed-process**'s `readProcess` so that the command
+to be executed can be logged. Bit of an annoyance that the command and the
+arguments have to be specified to `proc` separately, but that's _execvp(3)_
+for you.
+
+TODO this could potentially move to the **unbeliever** library
+-}
+execProcess :: [String] -> Program a (ExitCode, Rope, Rope)
+execProcess [] = error "No command provided"
+execProcess (cmd:args) =
+  let
+    task = proc cmd args
+    task' = setStdin closed task
+    command = List.intercalate " " (cmd:args)
+  in do
+    debugS "command" command
+
+    (exit, out, err) <- liftIO $ do
+        readProcess task'
+
+    return (exit, intoRope out, intoRope err)


### PR DESCRIPTION
Mostly as an effort to provide error messages from the LaTeX processor that are localized to a filename that is related to the input source fragment, write individual intermediate files rather than a single concatenated _.tex_ file.