### PR TITLE
Enable encapsulation of rendering back-end in a Docker container

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version:  0.1.5
+version:  0.1.6
 synopsis: Publishing tools for papers, books, and presentations
 license: BSD3
 license-file: LICENCE
@@ -18,7 +18,7 @@ dependencies:
  - pandoc
  - text
  - typed-process
- - unbeliever
+ - unbeliever >= 0.6
  - unix
  - unordered-containers
 
@@ -33,3 +33,4 @@ executables:
      - LatexPreamble
      - OutputParser
      - Utilities
+     - Paths_publish

--- a/src/RenderMain.hs
+++ b/src/RenderMain.hs
@@ -6,17 +6,24 @@ module Main where
 import Core.Program
 import Core.Text
 import RenderDocument (program, initial)
+import Paths_publish (version)
 
 
 main :: IO ()
 main = do
-    context <- configure initial (simple
-        [ Option "default-preamble" (Just 'p') [quote|
+    context <- configure (fromPackage version) initial (simple
+        [ Option "default-preamble" (Just 'p') Empty [quote|
             Wrap a built-in default LaTeX preamble (and ending) around your
             supplied source fragments. Most documents will put their own
             custom preamble as the first fragment in the .book file, but
             for getting started a suitable default can be employed via this
             option.
+          |]
+        , Option "docker" Nothing (Value "IMAGE") [quote|
+            Run the specified Docker image in a container, mount the target
+            directory into it as a volume, and do the build there. This allows
+            you to have all of the LaTeX dependencies separate from the machine
+            you are editing on.
           |]
         , Argument "bookfile" [quote|
             The file containing the list of fragments making up this book.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.12
+resolver: lts-12.18
 packages:
  - /home/andrew/src/oprdyn/unbeliever
  - .


### PR DESCRIPTION
Add new option `--docker` specifying Docker image to be instantiated as a container. The `latexmk` command can be run in there rather than in _/tmp_ on the host system. The tmpdir is volume mounted into the container.