### PR TITLE
Copy files to tmpdir only when they are newer

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version:  0.1.6
+version:  0.1.7
 synopsis: Publishing tools for papers, books, and presentations
 license: BSD3
 license-file: LICENCE
@@ -12,6 +12,7 @@ tested-with: GHC == 8.4
 dependencies:
  - base
  - bytestring
+ - chronologique
  - directory
  - filepath
  - pandoc-types


### PR DESCRIPTION
Preliminary support to reduce work done on rebuilds. For the case that source file has not changed since originally copied to the temp directory, don't re-copy it, and thus **latexmk** should not attempt to reprocess that part of the intermediate collection.