### PR TITLE
Force Verbatim passages to be on same page

### DIFF
--- a/src/LatexPreamble.hs
+++ b/src/LatexPreamble.hs
@@ -101,7 +101,7 @@ beginning = [quote|
 \usepackage{color}
 \usepackage{fancyvrb}
 \newcommand{\VerbBar}{|}
-\newcommand{\VERB}{\Verb[commandchars=\\\{\}]}
+\newcommand{\VERB}{\Verb[commandchars=\\\{\},samepage=true]}
 \DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}}
 % Add ',fontsize=\small' for more characters per line
 \usepackage{framed}


### PR DESCRIPTION
Adjust custom `Verbatim` environment to force verbatim code blocks to be on the same page.

Closes #37 