### PR TITLE
Program to emit a static site

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version: 2.1.1
+version: 2.2.0
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.
@@ -62,6 +62,15 @@ executables:
     other-modules:
      - FormatDocument
      - PandocToMarkdown
+
+  static:
+    source-dirs: src
+    main: StaticMain.hs
+    other-modules:
+     - Environment
+     - ParseBookfile
+     - StaticDocument
+     - Utilities
 
 tests:
   check:

--- a/src/StaticDocument.hs
+++ b/src/StaticDocument.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module StaticDocument
+    ( program
+    )
+where
+
+import Core.Program
+import Core.System
+import Core.Text
+
+import Environment (Env(..))
+
+program :: Program Env ()
+program = undefined

--- a/src/StaticMain.hs
+++ b/src/StaticMain.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Main where
+
+import Core.Program
+import Core.Text
+
+import StaticDocument (program)
+
+version :: Version
+version = $(fromPackage)
+
+main :: IO ()
+main = do
+    context <- configure version None (simple
+        [ Argument "bookfile" [quote|
+            The file containing the list of fragments making up this site.
+            If the argument is specified as "Hobbit.book" then "Hobbit"
+            will be used as the basename for the final output .html file.
+          |]
+        ])
+
+    executeWith context program


### PR DESCRIPTION
While the original and declared purpose of **publish** is to render beautiful PDFs, given our use of **pandoc** under the hood it is not a far stretch to consider using these tools to emit HTML (or at least, convert to HTML fragments which can then be reused).

This branch adds a _static_ program to the package, taking a _.book_ file and convert its fragments to HTML so we can experiment with subsequent "site" generation tools.

This is /not/ intended to be a full-featured static site generator!