### PR TITLE
Switch to LuaLaTeX

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version: 2.1.1
+version: 2.1.2
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -477,7 +477,7 @@ renderPDF = do
           [ "latexmk"
           ]
       options =
-        [ "-xelatex",
+        [ "-lualatex",
           "-output-directory=" ++ tmpdir,
           "-interaction=nonstopmode",
           "-halt-on-error",

--- a/src/RenderMain.hs
+++ b/src/RenderMain.hs
@@ -14,6 +14,7 @@ import RenderDocument (program)
 version :: Version
 version = "0"
 #else
+version :: Version
 version = $(fromPackage)
 #endif
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-15.11
+resolver: lts-15.16
 packages:
  - .


### PR DESCRIPTION
Switch from **xelatex** to **lualatex**. Some aspects of xe- were getting dated. Apparently the lua- engine supports the same font and unicode control, so we'll trial it.