### PR TITLE
Don't set up inotify watches when files are duplicated

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version: 2.1.3
+version: 2.1.4
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.
@@ -34,6 +34,7 @@ dependencies:
  - text
  - typed-process
  - core-text >= 0.2.2.3
+ - core-data
  - core-program >= 0.2.2.3
  - unix
  - unordered-containers

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -8,6 +8,7 @@ module RenderDocument
 where
 
 import Control.Monad (filterM, forM_, forever, void)
+import Core.Data
 import Core.Program
 import Core.System
 import Core.Text
@@ -108,8 +109,16 @@ renderDocument mode file = do
         Cycle -> return ()
     )
 
-  -- question: original lists or filtered ones?
-  return (file : preambles ++ fragments ++ trailers)
+  return (uniqueList file preambles fragments trailers)
+
+--
+-- Quickly reduce the fragment names to a unique list so we don't waste
+-- inotify watches.
+--
+uniqueList :: FilePath -> [FilePath] -> [FilePath] -> [FilePath] -> [FilePath]
+uniqueList file preambles fragments trailers =
+  let files = insertElement file (intoSet trailers <> (intoSet preambles <> intoSet fragments))
+   in fromSet files
 
 extractMode :: Parameters -> Program Env Mode
 extractMode params =


### PR DESCRIPTION
One of those "features we hadn't planned for but worked anyway" (how rare is that?) was that if you re-use a fragment everything still renders fine. Cool!

However, after doing so in `--watch` mode, the resultant list of files (inefficiently concatenated, btw) was fed to inotify resulting in duplicate watches. That's really quite wasteful, especially when the file is supremely unlikely to be the one changing.

Fix by building a Set and firing the resultant unique list off to be watched.