### PR TITLE
Add option to leave the generated PDF in /tmp

### DIFF
--- a/src/RenderMain.hs
+++ b/src/RenderMain.hs
@@ -46,6 +46,15 @@ main = do
             rendering engine if changes are detected.
           |],
             Option
+              "no-copy"
+              Nothing
+              Empty
+              [quote|
+            Should the resultant PDF be copied to this directory? Of course
+            it should, so the default is true. Select this if you want to
+            leave the file in /tmp.
+          |],
+            Option
               "temp"
               Nothing
               (Value "TMPDIR")


### PR DESCRIPTION
When doing `--watch` mode, it's a bit silly to keep blatting the disk with endless copies of a potentially huge PDF. Add a new option `--no-copy` to _not_ copy the resultant PDF if we simply have a view of it open in _/tmp_.