### PR TITLE
Use Inkscape to convert SVGs to PDF fragments

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version: 2.1.4
+version: 2.1.5
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -411,12 +411,13 @@ convertImage :: FilePath -> Program Env ()
 convertImage file = do
   env <- getApplicationState
   let tmpdir = tempDirectoryFrom env
-      target = tmpdir ++ "/" ++ replaceExtension file ".pdf"
-      buffer = target ++ "-tmp"
-      rsvgConvert =
-        [ "rsvg-convert",
-          "--format=pdf",
-          "--output=" ++ buffer,
+      basepath = takeExtension file
+      target = tmpdir ++ "/" ++ basepath ++ ".pdf"
+      buffer = tmpdir ++ "/" ++ basepath ++ "~tmp.pdf"
+      inkscape =
+        [ "inkscape",
+          "--export-type=pdf",
+          "--export-filename=" ++ buffer,
           file
         ]
 
@@ -424,7 +425,7 @@ convertImage file = do
     debugS "target" target
     (exit, out, err) <- do
       ensureDirectory target
-      execProcess rsvgConvert
+      execProcess inkscape
 
     case exit of
       ExitFailure _ -> do

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -28,7 +28,8 @@ import System.Directory
   )
 import System.Exit (ExitCode (..))
 import System.FilePath.Posix
-  ( replaceDirectory,
+  ( dropExtension,
+    replaceDirectory,
     replaceExtension,
     splitFileName,
     takeBaseName,
@@ -411,7 +412,7 @@ convertImage :: FilePath -> Program Env ()
 convertImage file = do
   env <- getApplicationState
   let tmpdir = tempDirectoryFrom env
-      basepath = takeExtension file
+      basepath = dropExtension file
       target = tmpdir ++ "/" ++ basepath ++ ".pdf"
       buffer = tmpdir ++ "/" ++ basepath ++ "~tmp.pdf"
       inkscape =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-16.5
+resolver: lts-16.10
 packages:
  - .


### PR DESCRIPTION
We've been using **rsvg-convert** to convert SVGs to PDF fragments. At some point recently it started struggling with the text component of some graphics. We use **inkscape** to create SVG graphics and it has high quality PDF export; this can be driven in headless mode from the command-line now. This was originally a part of the LaTeX dual layer output but we can export to PDF directly now.