### PR TITLE
Special characters need to be escaped

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version: 2.1.6
+version: 2.2.1
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.

--- a/src/PandocToMarkdown.hs
+++ b/src/PandocToMarkdown.hs
@@ -372,9 +372,20 @@ and replace the escaped space on output.
 -}
 stringToMarkdown :: T.Text -> Rope
 stringToMarkdown =
-    mconcat . intersperse "\\ " . breakPieces isNonBreaking . intoRope
+    escapeSpecialWith '\x00a0' ' '
+        . escapeSpecial '['
+        . escapeSpecial ']'
+        . escapeSpecial '_'
+        . intoRope
+
+escapeSpecial :: Char -> Rope -> Rope
+escapeSpecial c = escapeSpecialWith c c
+
+escapeSpecialWith :: Char -> Char -> Rope -> Rope
+escapeSpecialWith needle replacement =
+    mconcat . intersperse (singletonRope '\\' <> singletonRope replacement) . breakPieces isNeedle . intoRope
   where
-    isNonBreaking c = c == '\x00a0'
+    isNeedle c = c == needle
 
 imageToMarkdown :: Attr -> [Inline] -> (T.Text, T.Text) -> Rope
 imageToMarkdown attr inlines (url, title) =

--- a/tests/fragments/Paragraphs.markdown
+++ b/tests/fragments/Paragraphs.markdown
@@ -12,3 +12,6 @@ in the ancient dialect,
 these need to be treated specially when represented as Markdown. Otherwise the
 lines that aren't lines will end up as lines that are part of other lines, and
 be wrapped, or unwrapped, accordingly.
+
+Worst of all, however, is that some things \[not what you'd expect\] need to
+be _\_really\__ escaped.


### PR DESCRIPTION
Bracket characters `'['` and `']'` need to be escaped when they're not part of hyperlinks.

Pandoc's Markdown writer obviously already does a stellar job of this part, but alas.