### PR TITLE
Zero timer before re-rendering

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version: 2.2.1
+version: 2.2.2
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs.

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -61,7 +61,6 @@ program = do
     params <- getCommandLine
     (mode, copy) <- extractMode params
 
-    resetTimer
     event "Identify .book file"
     bookfile <- extractBookFile params
 
@@ -71,11 +70,10 @@ program = do
             void (renderDocument (mode, copy) bookfile)
         Cycle -> do
             -- use inotify to rebuild on changes
-            forever (renderDocument (mode, copy) bookfile >>= waitForChange)
+            forever (renderDocument (mode, copy) bookfile >>= waitForChange >> resetTimer)
 
 renderDocument :: (Mode, Copy) -> FilePath -> Program Env [FilePath]
 renderDocument (mode, copy) file = do
-    resetTimer
     event "Read .book file"
     book <- processBookFile file
 

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -61,6 +61,7 @@ program = do
     params <- getCommandLine
     (mode, copy) <- extractMode params
 
+    resetTimer
     event "Identify .book file"
     bookfile <- extractBookFile params
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.10
+resolver: lts-17.12
 
 packages:
   - .
@@ -6,6 +6,7 @@ packages:
 extra-deps:
   - core-program-0.2.7.1
   - hslua-module-path-0.1.0.1
+  - texmath-0.12.2
   - pandoc-2.13
 
 nix:


### PR DESCRIPTION
Use new feature in **core-program** allowing us to reset the timer so we can show the duration of a render each time we do so. Much nicer when we're rendering in file watch mode.