### PR TITLE
Update GHC

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ dependencies:
  - core-data
  - core-program >= 0.3.1
  - core-telemetry >= 0.1.7.2
+ - safe-exceptions
  - unix
  - unordered-containers
 

--- a/src/PandocToMarkdown.hs
+++ b/src/PandocToMarkdown.hs
@@ -9,6 +9,7 @@ module PandocToMarkdown (
     tableToMarkdown,
 ) where
 
+import qualified Control.Exception.Safe as Safe (impureThrow)
 import Core.System.Base
 import Core.Text
 import Data.Foldable (foldl')
@@ -275,7 +276,7 @@ tableToMarkdown _ _ alignments thead tbodys _ =
 
     headerToMarkdown :: TableHead -> Rope
     headerToMarkdown (TableHead _ [row]) = rowToMarkdown row
-    headerToMarkdown _ = impureThrow (NotSafe "What do we do with this TableHead?")
+    headerToMarkdown _ = Safe.impureThrow (NotSafe "What do we do with this TableHead?")
 
     columnToMarkdown :: (Alignment, ColWidth) -> Rope
     columnToMarkdown (align, col) =
@@ -317,13 +318,13 @@ tableToMarkdown _ _ alignments thead tbodys _ =
     cellToMarkdown (Cell _ _ (RowSpan 1) (ColSpan 1) [block]) =
         convert block
     cellToMarkdown _ =
-        impureThrow (NotSafe "Multiple Blocks encountered")
+        Safe.impureThrow (NotSafe "Multiple Blocks encountered")
 
     convert :: Block -> Rope
     convert (Plain inlines) =
         plaintextToMarkdown 100000 inlines
     convert _ =
-        impureThrow (NotSafe "Incorrect Block type encountered")
+        Safe.impureThrow (NotSafe "Incorrect Block type encountered")
 
 data NotSafe = NotSafe String
     deriving (Show)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,9 @@
-resolver: lts-18.21
-
+resolver: nightly-2022-09-23
 packages:
-  - .
+- .
 
 extra-deps:
-  - core-text-0.3.5.0
-  - core-data-0.3.0.2
-  - core-program-0.4.2.0
-  - core-telemetry-0.1.8.1
+- core-data-0.3.6.0
+- core-program-0.5.2.0
+- core-text-0.3.8.0
+- core-telemetry-0.2.6.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-09-23
+resolver: nightly-2022-09-28
 packages:
 - .
 

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -1,17 +1,18 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 import CheckBookfileParser
 import CheckTableProperties
 import CompareFragments
-import Core.System
+import Control.Exception.Safe qualified as Safe
 import Test.Hspec
 
 main :: IO ()
 main = do
-  finally (hspec suite) (putStrLn ".")
+    Safe.finally (hspec suite) (putStrLn ".")
 
 suite :: Spec
 suite = do
-  checkTableProperties
-  checkByComparingFragments
-  checkBookfileParser
+    checkTableProperties
+    checkByComparingFragments
+    checkBookfileParser

--- a/tests/fragments/PipeTable.md
+++ b/tests/fragments/PipeTable.md
@@ -1,7 +1,7 @@
 Introduction this is.
 
 | Centered Header | Default Aligned | Right Aligned | Left Aligned |
-|:------:|--------|-------:|:-------|
+|:-----------------:|-------------------|------------------:|:------------------|
 | First | row1 | `12.0` | Example of a row that goes on and on and spans multiple lines. |
 | Second | row2 | `5.0` | Here’s another one. Note the blank line between rows. |
 | Tee | row3 | `4567.1` | Now this is interesting. |


### PR DESCRIPTION
Now that **haskell-language-server** is supporting GHC 9.2.4, update the Stackage snapshot to the current `nightly`, bump the **core-\*** package versions, and fix some imports and formatting.