### PR TITLE
Upkeep maintenance

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,7 +21,7 @@ author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2016-2023 Athae Eredh Siniath and Others
 category: Text
-tested-with: GHC == 9.2.5
+tested-with: GHC == 9.4.6
 github: aesiniath/publish
 
 dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version: 2.5.3
+version: 2.5.4
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs. There are two
@@ -27,7 +27,6 @@ github: aesiniath/publish
 dependencies:
  - base >= 4.11 && < 5
  - bytestring
- - chronologique
  - deepseq
  - directory
  - filepath
@@ -38,7 +37,7 @@ dependencies:
  - text
  - typed-process
  - core-text >= 0.3.4
- - core-data
+ - core-data >= 0.3.3
  - core-program >= 0.6.5
  - core-telemetry >= 0.2.7
  - safe-exceptions

--- a/src/PandocToMarkdown.hs
+++ b/src/PandocToMarkdown.hs
@@ -61,7 +61,6 @@ convertBlock margin block =
             Plain inlines -> plaintextToMarkdown margin inlines
             Para inlines -> paragraphToMarkdown margin inlines
             Header level _ inlines -> headingToMarkdown level inlines
-            Null -> emptyRope
             RawBlock (Format "tex") string -> intoRope string <> "\n"
             RawBlock (Format "html") string -> intoRope string <> "\n"
             RawBlock _ _ -> error msg
@@ -74,6 +73,7 @@ convertBlock margin block =
             HorizontalRule -> "---\n"
             Table attr caption alignments header rows footer -> tableToMarkdown attr caption alignments header rows footer
             Div attr blocks -> divToMarkdown margin attr blocks
+            Figure _ _ _ -> error msg
 
 {-
 This does **not** emit a newline at the end. The intersperse happening in

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -8,8 +8,8 @@ module Utilities (
     isNewer,
 ) where
 
-import Chrono.Compat (convertToUTC)
 import Control.Monad (when)
+import Core.Data
 import Core.Program
 import Core.System
 import System.Directory (
@@ -61,5 +61,5 @@ isNewer source target = liftIO $ do
     time2 <-
         doesFileExist target >>= \case
             True -> getModificationTime target
-            False -> return (convertToUTC 0) -- the epoch
+            False -> return (fromTime epochTime)
     return (time1 > time2)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
-resolver: lts-20.11
-compiler: ghc-9.2.5
+resolver: lts-21.15
+compiler: ghc-9.4.6
 packages:
 - .
 
 extra-deps:
-- core-program-0.6.5.0
+- core-program-0.6.9.4


### PR DESCRIPTION
Bump resolver to `lts-21.15` and GHC 9.4.6 for building.

Update case matches for the Block type to resolve the breaking changes made at **pandoc** 3.0.

Remove **chronologique** and replace with code that was ported to **core-data**.