### PR TITLE
Change SVG to PDF conversion back to rsvg-convert

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: publish
-version: 2.5.4
+version: 2.6.0
 synopsis: Publishing tools for papers, books, and presentations
 description: |
   Tools for rendering markdown-centric documents into PDFs. There are two

--- a/src/RenderDocument.hs
+++ b/src/RenderDocument.hs
@@ -445,10 +445,12 @@ convertImage file = do
             basepath = dropExtension file
             target = tmpdir ++ "/" ++ basepath ++ ".pdf"
             buffer = tmpdir ++ "/" ++ basepath ++ "~tmp.pdf"
-            inkscape =
-                [ "inkscape"
-                , "--export-type=pdf"
-                , "--export-filename=" ++ buffer
+            convert =
+                [ "rsvg-convert"
+                , "--format"
+                , "pdf"
+                , "--output"
+                , buffer
                 , file
                 ]
 
@@ -456,7 +458,7 @@ convertImage file = do
             debugS "target" target
             (exit, out, err) <- do
                 ensureDirectory target
-                readProcess (fmap intoRope inkscape)
+                readProcess (fmap intoRope convert)
 
             case exit of
                 ExitFailure _ -> do


### PR DESCRIPTION
For reasons that don't seem entirely rational, Inkscape is suddenly having trouble rendering SVGs to PDFs from the command-line. It seems to be related to a problem in **gtk** or **glib** related to sequencing of asynchronous operations over DBus at shutdown. Uh huh. Inkscape crashes, though, and that's unhelpful. See https://gitlab.com/inkscape/inkscape/-/issues/4177 and https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/6180.

There are patches in but not yet released (not in Fedora 38, anyway) and since the workarounds don't seem to help I've temporarily reverted back to letting **librsvg2**'s _rsvg-convert_ do the conversion like Publish did originally. It might not be bullet-proof for more complex illustrations but it'll do for now.