### PR TITLE
Remove LaTeX workaround

### DIFF
--- a/src/LatexPreamble.hs
+++ b/src/LatexPreamble.hs
@@ -152,6 +152,11 @@ beginning =
 \newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
 \newcommand{\WarningTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
 
+%
+% Enable strikeout (specifically the \st command)
+%
+
+\usepackage{soul}
 |]
     <> "\\hypersetup{pdfproducer={Markdown and Latex rendered via Publish "
     <> intoRope (versionNumberFrom version)

--- a/src/LatexPreamble.hs
+++ b/src/LatexPreamble.hs
@@ -152,13 +152,6 @@ beginning =
 \newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
 \newcommand{\WarningTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
 
-%
-% avoid problems with \sout in headers with hyperref:
-%
-
-\usepackage[normalem]{ulem}
-\pdfstringdefDisableCommands{\renewcommand{\sout}{}}
-
 |]
     <> "\\hypersetup{pdfproducer={Markdown and Latex rendered via Publish "
     <> intoRope (versionNumberFrom version)


### PR DESCRIPTION
Remove workaround no longer required due to ongoing evolution in Pandoc. Specifically, it uses the **sout** package now rather than **ulem** and so this fragment, which originated in the upstream preamble, can be removed.