### PR TITLE
Support GHC 9.6.5

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-22.22
-compiler: ghc-9.6.4
+resolver: lts-22.23
+compiler: ghc-9.6.5
 packages:
 - .
 ghc-options:


### PR DESCRIPTION
Bump resolver to lts-22.23 and start using GHC 9.6.5 to build.